### PR TITLE
New prod gold external apps model for bubble to new sessionops migration api

### DIFF
--- a/models/gold/external_apps/prod_academic_year_migration.sql
+++ b/models/gold/external_apps/prod_academic_year_migration.sql
@@ -1,0 +1,58 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `academic_year` table.
+-- Sourced directly from bubble_raw (not stg_bubble__academic_year) because bronze
+-- casts Created_Date/Modified_Date to ::date, discarding the time-of-day that the
+-- target TIMESTAMPTZ columns (created_at/updated_at) need for migration fidelity.
+--
+-- Business rules applied here that have no equivalent in bubble:
+--   * is_active: bubble currently has multiple rows flagged active at once, which
+--     violates the target's single-active-row constraint (uniq_active_academic_year).
+--     Only the row with the latest Modified_Date is kept active; all others are false.
+--   * created_by/updated_by: bubble's Created_By is sometimes a backend workflow
+--     identifier (e.g. 'admin_user_session-commencement_live') rather than a real
+--     user._id, so it can't resolve via the normal UUID join. Falls back to the
+--     'admin' user (user_id 477022) whenever the join finds no match.
+--   * removed/deleted_at: bubble's academic_year table has no equivalent columns,
+--     so these are hardcoded to false / null.
+--   * updated_by: bubble tracks no separate "modified by" actor, so it mirrors
+--     the resolved created_by value.
+
+with raw as (
+    select
+        "academic_year_id"::bigint as academic_year_id,
+        "label" as label,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'academic_year') }}
+),
+
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+resolved as (
+    select
+        raw.academic_year_id,
+        raw.label,
+        raw.created_at,
+        raw.updated_at,
+        coalesce(user_map.user_id_number, 477022) as resolved_user_id,
+        row_number() over (order by raw.updated_at desc) as recency_rank
+    from raw
+    left join user_map on raw.created_by_uuid = user_map.uuid
+)
+
+select
+    academic_year_id,
+    label::varchar(20) as label,
+    (recency_rank = 1) as is_active,
+    false as removed,
+    cast(null as timestamptz) as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from resolved

--- a/models/gold/external_apps/prod_batch_child_migration.sql
+++ b/models/gold/external_apps/prod_batch_child_migration.sql
@@ -1,0 +1,95 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `batch_child` table.
+-- Sourced directly from bubble_raw (not stg_bubble__batch_child) for
+-- created_at/updated_at precision — see prod_academic_year_migration.sql for why.
+--
+-- FK resolution (all resolve cleanly, 0 unmatched rows in bubble_raw as of this build):
+--   * child_id            -> child._id            -> child.child_id       (stg_bubble__children)
+--   * school_id           -> partner._id           -> partner.partner_id  (stg_bubble__partner)
+--     Loose/logical reference per the target schema (school_id is a plain BigIntegerField,
+--     not a DB-level FK), but still needs the same UUID->integer resolution.
+--   * school_academic_year_id -> school_academic_year._id -> school_academic_year.school_academic_year_id
+--     (stg_bubble__school_academic_year)
+--
+-- created_by/updated_by: ~189 rows have a null raw Created_By, and many more carry a
+-- Created_By UUID with no matching row in bubble_raw."user" (deleted/unsynced users).
+-- Falls back to the 'admin' user (user_id 477022) whenever unresolved, same rule as
+-- prod_academic_year_migration.sql. bubble tracks no separate "modified by" actor, so
+-- updated_by mirrors the resolved created_by value.
+--
+-- Raw batch_child_id is not unique in bubble_raw (8148 rows / 8115 distinct ids as of
+-- this build) - deduplicated to one row per batch_child_id, keeping the latest by
+-- Modified_Date.
+
+with raw as (
+    select
+        "batch_child_id"::bigint as batch_child_id,
+        "child_id" as child_uuid,
+        "school_id" as school_uuid,
+        "school_academic_year_id" as school_academic_year_uuid,
+        "is_active"::boolean as is_active,
+        "removed"::boolean as removed,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'batch_child') }}
+),
+
+child_map as (
+    select _id as uuid, child_id
+    from {{ ref('stg_bubble__children') }}
+),
+partner_map as (
+    select partner_id as uuid, partner_id1 as school_id
+    from {{ ref('stg_bubble__partner') }}
+),
+school_academic_year_map as (
+    select "_id" as uuid, school_academic_year_id
+    from {{ ref('stg_bubble__school_academic_year') }}
+),
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+joined as (
+    select
+        raw.batch_child_id,
+        school_academic_year_map.school_academic_year_id,
+        child_map.child_id,
+        partner_map.school_id,
+        raw.is_active,
+        raw.removed,
+        raw.created_at,
+        raw.updated_at,
+        coalesce(user_map.user_id_number, 477022) as resolved_user_id
+    from raw
+    left join child_map on raw.child_uuid = child_map.uuid
+    left join partner_map on raw.school_uuid = partner_map.uuid
+    left join school_academic_year_map on raw.school_academic_year_uuid = school_academic_year_map.uuid
+    left join user_map on raw.created_by_uuid = user_map.uuid
+),
+
+deduplicated as (
+    {{ dbt_utils.deduplicate(
+        relation='joined',
+        partition_by='batch_child_id',
+        order_by='updated_at desc',
+       )
+    }}
+)
+
+select
+    batch_child_id,
+    school_academic_year_id,
+    child_id,
+    school_id,
+    is_active,
+    removed,
+    cast(null as timestamptz) as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from deduplicated

--- a/models/gold/external_apps/prod_child_class_migration.sql
+++ b/models/gold/external_apps/prod_child_class_migration.sql
@@ -1,0 +1,87 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `child_class` table.
+-- Sourced directly from bubble_raw (not stg_bubble__child_class) for
+-- created_at/updated_at precision - see prod_academic_year_migration.sql for why.
+--
+-- FK resolution (both resolve cleanly, 0 unmatched rows in bubble_raw as of this build):
+--   * child_id        -> child._id        -> child.child_id        (stg_bubble__children)
+--   * school_class_id -> school_class._id -> school_class.school_class_id (stg_bubble__school_class)
+--
+-- Per the .md notes: bubble/target both enforce "one active child_class per child" only
+-- at the service layer, not the DB - no UniqueConstraint exists on either side. Checked
+-- current data for violations (multiple is_active=true/removed=false rows per child_id):
+-- none found as of this build, so no cleanup pass is needed here. The invariant itself
+-- is a service-layer concern for the new platform, not something this model can enforce.
+--
+-- created_by/updated_by: ~189 rows have a null raw Created_By, and ~918 more carry a
+-- Created_By UUID with no matching row in bubble_raw."user". Falls back to the 'admin'
+-- user (user_id 477022) whenever unresolved, same rule as the other migration models.
+-- bubble tracks no separate "modified by" actor, so updated_by mirrors created_by.
+--
+-- Raw child_class_id is not unique in bubble_raw (8190 rows / 8155 distinct ids as of
+-- this build) - deduplicated to one row per id, keeping the latest by Modified_Date.
+
+with raw as (
+    select
+        "child_class_id"::bigint as child_class_id,
+        "child_id" as child_uuid,
+        "school_class_id" as school_class_uuid,
+        "is_active"::boolean as is_active,
+        "removed"::boolean as removed,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'child_class') }}
+),
+
+child_map as (
+    select _id as uuid, child_id
+    from {{ ref('stg_bubble__children') }}
+),
+school_class_map as (
+    select "_id" as uuid, school_class_id
+    from {{ ref('stg_bubble__school_class') }}
+),
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+joined as (
+    select
+        raw.child_class_id,
+        child_map.child_id,
+        school_class_map.school_class_id,
+        raw.is_active,
+        raw.removed,
+        raw.created_at,
+        raw.updated_at,
+        coalesce(user_map.user_id_number, 477022) as resolved_user_id
+    from raw
+    left join child_map on raw.child_uuid = child_map.uuid
+    left join school_class_map on raw.school_class_uuid = school_class_map.uuid
+    left join user_map on raw.created_by_uuid = user_map.uuid
+),
+
+deduplicated as (
+    {{ dbt_utils.deduplicate(
+        relation='joined',
+        partition_by='child_class_id',
+        order_by='updated_at desc',
+       )
+    }}
+)
+
+select
+    child_class_id,
+    child_id,
+    school_class_id,
+    is_active,
+    removed,
+    cast(null as timestamptz) as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from deduplicated

--- a/models/gold/external_apps/prod_child_class_section_migration.sql
+++ b/models/gold/external_apps/prod_child_class_section_migration.sql
@@ -1,0 +1,91 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `child_class_section` table.
+-- Sourced directly from bubble_raw (not stg_bubble__child_class_section, and not
+-- int_bubble__child_class_section) because:
+--   1. created_at/updated_at need full timestamp precision - see
+--      prod_academic_year_migration.sql for why bronze's ::date cast is unusable here.
+--   2. int_bubble__child_class_section doesn't carry is_active or created_by through
+--      its select list, both of which the target schema needs - resolving independently
+--      here rather than modifying that shared silver model for one consumer.
+--
+-- FK resolution:
+--   * child_id         -> child._id         -> child.child_id         (stg_bubble__children)
+--   * class_section_id -> class_section._id -> class_section.class_section_id (stg_bubble__class_section)
+--
+-- 47 rows in bubble_raw have a NULL class_section_id (21 of them otherwise look "live":
+-- is_active=true, removed=false). class_section_id is NOT NULL on the target, so these
+-- rows can't load there - excluded here rather than migrated with a broken FK.
+--
+-- created_by/updated_by: ~195 rows have a null raw Created_By, and ~836 more carry a
+-- Created_By UUID with no matching row in bubble_raw."user". Falls back to the 'admin'
+-- user (user_id 477022) whenever unresolved, same rule as the other migration models.
+-- bubble tracks no separate "modified by" actor, so updated_by mirrors created_by.
+--
+-- Raw child_class_section_id is not unique in bubble_raw (8655 rows / 8619 distinct ids
+-- as of this build) - deduplicated to one row per id, keeping the latest by Modified_Date.
+
+with raw as (
+    select
+        "child_class_section_id"::bigint as child_class_section_id,
+        "child_id" as child_uuid,
+        "class_section_id" as class_section_uuid,
+        "is_active"::boolean as is_active,
+        "removed"::boolean as removed,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'child_class_section') }}
+),
+
+child_map as (
+    select _id as uuid, child_id
+    from {{ ref('stg_bubble__children') }}
+),
+class_section_map as (
+    select "_id" as uuid, class_section_id
+    from {{ ref('stg_bubble__class_section') }}
+),
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+joined as (
+    select
+        raw.child_class_section_id,
+        child_map.child_id,
+        class_section_map.class_section_id,
+        raw.is_active,
+        raw.removed,
+        raw.created_at,
+        raw.updated_at,
+        coalesce(user_map.user_id_number, 477022) as resolved_user_id
+    from raw
+    left join child_map on raw.child_uuid = child_map.uuid
+    left join class_section_map on raw.class_section_uuid = class_section_map.uuid
+    left join user_map on raw.created_by_uuid = user_map.uuid
+    where class_section_map.class_section_id is not null
+),
+
+deduplicated as (
+    {{ dbt_utils.deduplicate(
+        relation='joined',
+        partition_by='child_class_section_id',
+        order_by='updated_at desc',
+       )
+    }}
+)
+
+select
+    child_class_section_id,
+    child_id,
+    class_section_id,
+    is_active,
+    removed,
+    cast(null as timestamptz) as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from deduplicated

--- a/models/gold/external_apps/prod_child_migration.sql
+++ b/models/gold/external_apps/prod_child_migration.sql
@@ -1,0 +1,113 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `child` table.
+-- Sourced directly from bubble_raw (not stg_bubble__children) for two reasons:
+--   1. created_at/updated_at need full timestamp precision - see
+--      prod_academic_year_migration.sql for why bronze's ::date cast is unusable here.
+--   2. dob/date_of_enrollment need a timezone fix - see below.
+--
+-- Per the .md M7 notes: post-M6, class enrollment lives on child_class /
+-- child_class_section, not on Child - class_id and school_class_id are intentionally
+-- NOT carried into this output even though bubble_raw.child still has them.
+-- guardian_name/guardian_phone/admission_number (dropped in the target's migration 0012)
+-- don't exist in bubble_raw.child either, so there's nothing to drop.
+--
+-- gender mapping: bubble_raw uses 'Male'/'Female'/'Others' (2859/2449/2 rows); target
+-- only allows male/female/other. Lowercased, with Others -> other.
+--
+-- dob/date_of_enrollment timezone fix: every non-null value in both columns has exactly
+-- '18:30:00' as its UTC time component (839/839 and 264/264 rows) - the UTC
+-- representation of IST midnight (00:00 IST = 18:30 UTC the prior day). A direct ::date
+-- cast (what stg_bubble__children.sql currently does) reads the UTC calendar date, one
+-- day earlier than what was actually entered in Bubble. Converted to Asia/Kolkata before
+-- taking the date here so the migrated value matches the real entered date.
+--
+-- FK resolution: school_id -> partner._id -> partner.partner_id (stg_bubble__partner).
+-- Loose/logical reference per the target schema (school_id is a plain BigIntegerField,
+-- not a DB-level FK) - 0 unmatched rows in bubble_raw as of this build.
+--
+-- created_by/updated_by: ~189 rows have a null raw Created_By, and ~103 more carry a
+-- Created_By UUID with no matching row in bubble_raw."user". Falls back to the 'admin'
+-- user (user_id 477022) whenever unresolved, same rule as the other migration models.
+-- bubble tracks no separate "modified by" actor, so updated_by mirrors created_by.
+--
+-- mad_joining_date: no bubble equivalent - left null (nullable on the target).
+--
+-- Raw child_id is currently unique (5310 rows / 5310 distinct ids as of this build).
+
+with raw as (
+    select
+        "child_id"::bigint as child_id,
+        "school_id" as school_uuid,
+        "first_name" as first_name,
+        "last_name" as last_name,
+        case lower("gender")
+            when 'male' then 'male'
+            when 'female' then 'female'
+            when 'others' then 'other'
+            else lower("gender")
+        end as gender,
+        (("dob"::timestamptz) at time zone 'Asia/Kolkata')::date as date_of_birth,
+        "Age"::integer as age,
+        "city" as city,
+        "mother_tounge" as mother_tongue,
+        (("date_of_enrollment"::timestamptz) at time zone 'Asia/Kolkata')::date as date_of_enrollment,
+        "is_active"::boolean as is_active,
+        "removed"::boolean as removed,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'child') }}
+),
+
+partner_map as (
+    select partner_id as uuid, partner_id1 as school_id
+    from {{ ref('stg_bubble__partner') }}
+),
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+joined as (
+    select
+        raw.child_id,
+        partner_map.school_id,
+        raw.first_name,
+        raw.last_name,
+        raw.gender,
+        raw.date_of_birth,
+        raw.age,
+        raw.city,
+        raw.mother_tongue,
+        raw.date_of_enrollment,
+        raw.is_active,
+        raw.removed,
+        raw.created_at,
+        raw.updated_at,
+        coalesce(user_map.user_id_number, 477022) as resolved_user_id
+    from raw
+    left join partner_map on raw.school_uuid = partner_map.uuid
+    left join user_map on raw.created_by_uuid = user_map.uuid
+)
+
+select
+    child_id,
+    school_id,
+    first_name,
+    last_name,
+    gender,
+    date_of_birth,
+    age,
+    city,
+    mother_tongue,
+    date_of_enrollment,
+    cast(null as date) as mad_joining_date,
+    is_active,
+    removed,
+    cast(null as timestamptz) as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from joined

--- a/models/gold/external_apps/prod_child_program_migration.sql
+++ b/models/gold/external_apps/prod_child_program_migration.sql
@@ -1,0 +1,90 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `child_program` table.
+-- Sourced directly from bubble_raw (not stg_bubble__child_program) for
+-- created_at/updated_at precision - see prod_academic_year_migration.sql for why.
+--
+-- FK resolution:
+--   * child_id   -> child._id   -> child.child_id     (stg_bubble__children) - 0 unmatched.
+--   * program_id -> program._id -> program.program_id (stg_bubble__program)
+--
+-- 33 rows have a NULL program_id in bubble_raw (all 33 unresolved rows are exactly the
+-- null ones - no non-null UUID fails to match). program_id is NOT NULL on the target,
+-- so per instruction these rows fall back to program_id 1 ('Education Support') rather
+-- than being excluded.
+--
+-- is_active: bubble_raw.child_program has no is_active column at all (confirmed against
+-- the live raw table, not just the stg model - this isn't a dropped column). Hardcoded
+-- to true here, matching the target schema's own column default.
+--
+-- created_by/updated_by: ~189 rows have a null raw Created_By, and ~103 more carry a
+-- Created_By UUID with no matching row in bubble_raw."user". Falls back to the 'admin'
+-- user (user_id 477022) whenever unresolved, same rule as the other migration models.
+-- bubble tracks no separate "modified by" actor, so updated_by mirrors created_by.
+--
+-- Raw child_program_id is currently unique (5310 rows / 5310 distinct ids as of this
+-- build) but deduplicated anyway for safety, keeping the latest by Modified_Date -
+-- every sibling bubble raw table checked so far (batch_child, child_class_section,
+-- child_class) has turned out to carry duplicate ids from Airbyte re-syncs.
+
+with raw as (
+    select
+        "child_program_id"::bigint as child_program_id,
+        "child_id" as child_uuid,
+        "program_id" as program_uuid,
+        "removed"::boolean as removed,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'child_program') }}
+),
+
+child_map as (
+    select _id as uuid, child_id
+    from {{ ref('stg_bubble__children') }}
+),
+program_map as (
+    select "_id" as uuid, program_id
+    from {{ ref('stg_bubble__program') }}
+),
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+joined as (
+    select
+        raw.child_program_id,
+        child_map.child_id,
+        coalesce(program_map.program_id, 1) as program_id,
+        raw.removed,
+        raw.created_at,
+        raw.updated_at,
+        coalesce(user_map.user_id_number, 477022) as resolved_user_id
+    from raw
+    left join child_map on raw.child_uuid = child_map.uuid
+    left join program_map on raw.program_uuid = program_map.uuid
+    left join user_map on raw.created_by_uuid = user_map.uuid
+),
+
+deduplicated as (
+    {{ dbt_utils.deduplicate(
+        relation='joined',
+        partition_by='child_program_id',
+        order_by='updated_at desc',
+       )
+    }}
+)
+
+select
+    child_program_id,
+    program_id,
+    child_id,
+    true as is_active,
+    removed,
+    cast(null as timestamptz) as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from deduplicated

--- a/models/gold/external_apps/prod_child_subject_migration.sql
+++ b/models/gold/external_apps/prod_child_subject_migration.sql
@@ -1,0 +1,92 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `child_subject` table.
+-- Sourced directly from bubble_raw (not stg_bubble__child_subject) for
+-- created_at/updated_at precision - see prod_academic_year_migration.sql for why.
+--
+-- Per the .md [FLAG] notes: neither FK has an explicit db_column set on the target
+-- Django model, so Django appends '_id' to the already-'_id'-suffixed field name,
+-- producing doubled real column names. Output columns below use those exact doubled
+-- names (child_id_id, class_section_subject_id_id) per the "exact DB column names"
+-- convention agreed for this migration project.
+--
+-- FK resolution (both resolve cleanly, 0 unmatched rows in bubble_raw as of this build):
+--   * child_id_id                -> child._id                -> child.child_id (stg_bubble__children)
+--   * class_section_subject_id_id -> class_section_subject._id -> class_section_subject.class_section_subject_id
+--     (stg_bubble__class_section_subject)
+--
+-- created_by/updated_by: 0 null/unresolved Created_By rows in bubble_raw as of this
+-- build, but the admin fallback (user_id 477022) is kept for parity with the other
+-- migration models in case future syncs introduce unresolved values. bubble tracks no
+-- separate "modified by" actor, so updated_by mirrors created_by.
+--
+-- Reminder from the .md notes: this is a history-only record in bubble, never
+-- authoritative for a child's *current* subjects - carried through as-is for migration,
+-- not reinterpreted here.
+--
+-- Raw child_subject_id is not unique in bubble_raw (4924 rows / 4814 distinct ids as of
+-- this build) - deduplicated to one row per id, keeping the latest by Modified_Date.
+
+with raw as (
+    select
+        "child_subject_id"::bigint as child_subject_id,
+        "child_id" as child_uuid,
+        "class_section_subject_id" as class_section_subject_uuid,
+        "is_active"::boolean as is_active,
+        "removed"::boolean as removed,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'child_subject') }}
+),
+
+child_map as (
+    select _id as uuid, child_id
+    from {{ ref('stg_bubble__children') }}
+),
+class_section_subject_map as (
+    select "_id" as uuid, class_section_subject_id
+    from {{ ref('stg_bubble__class_section_subject') }}
+),
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+joined as (
+    select
+        raw.child_subject_id,
+        child_map.child_id,
+        class_section_subject_map.class_section_subject_id,
+        raw.is_active,
+        raw.removed,
+        raw.created_at,
+        raw.updated_at,
+        coalesce(user_map.user_id_number, 477022) as resolved_user_id
+    from raw
+    left join child_map on raw.child_uuid = child_map.uuid
+    left join class_section_subject_map on raw.class_section_subject_uuid = class_section_subject_map.uuid
+    left join user_map on raw.created_by_uuid = user_map.uuid
+),
+
+deduplicated as (
+    {{ dbt_utils.deduplicate(
+        relation='joined',
+        partition_by='child_subject_id',
+        order_by='updated_at desc',
+       )
+    }}
+)
+
+select
+    child_subject_id,
+    child_id as child_id_id,
+    class_section_subject_id as class_section_subject_id_id,
+    is_active,
+    removed,
+    cast(null as timestamptz) as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from deduplicated

--- a/models/gold/external_apps/prod_class_migration.sql
+++ b/models/gold/external_apps/prod_class_migration.sql
@@ -1,0 +1,80 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `class` table (global class/grade catalog).
+-- Sourced directly from bubble_raw (not stg_bubble__class) for two reasons:
+--   1. created_at/updated_at need full timestamp precision - see
+--      prod_academic_year_migration.sql for why bronze's ::date cast is unusable here.
+--   2. program_id is a plain numeric column in bubble_raw.class (not a UUID, unlike
+--      program_id on child_program) - it already points directly at program.program_id,
+--      so no UUID join is needed or possible here; passed through as-is.
+--
+-- is_active/removed: bubble_raw.class has neither column at all (only 9 columns total -
+-- confirmed against the live raw table, not just the stg model). Hardcoded to
+-- true/false here, matching the target schema's own column defaults.
+--
+-- class_code: numeric in bubble_raw (5,6,7,8...) but VARCHAR(4) on the target - cast to
+-- text.
+--
+-- created_by/updated_by: all 4 current rows have Created_By set to a backend workflow
+-- identifier ('admin_user_session-commencement_test'/'_live'), same pattern as
+-- prod_academic_year_migration.sql, not a real user._id. Falls back to the 'admin' user
+-- (user_id 477022) for all of them. created_by is nullable on this target (unlike most
+-- other migrated tables) but the admin fallback is applied anyway for consistency across
+-- all migration models. bubble tracks no separate "modified by" actor, so updated_by
+-- mirrors created_by.
+--
+-- Raw class_id is currently unique (4 rows / 4 distinct ids as of this build) - kept the
+-- dedupe anyway for consistency/safety with the other migration models.
+
+with raw as (
+    select
+        "class_id"::bigint as class_id,
+        "class_name" as class_name,
+        "class_code"::varchar(4) as class_code,
+        "program_id"::bigint as program_id,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'class') }}
+),
+
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+joined as (
+    select
+        raw.class_id,
+        raw.class_name,
+        raw.class_code,
+        raw.program_id,
+        raw.created_at,
+        raw.updated_at,
+        coalesce(user_map.user_id_number, 477022) as resolved_user_id
+    from raw
+    left join user_map on raw.created_by_uuid = user_map.uuid
+),
+
+deduplicated as (
+    {{ dbt_utils.deduplicate(
+        relation='joined',
+        partition_by='class_id',
+        order_by='updated_at desc',
+       )
+    }}
+)
+
+select
+    class_id,
+    class_name,
+    class_code,
+    program_id,
+    true as is_active,
+    false as removed,
+    cast(null as timestamptz) as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from deduplicated

--- a/models/gold/external_apps/prod_class_section_migration.sql
+++ b/models/gold/external_apps/prod_class_section_migration.sql
@@ -1,0 +1,91 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `class_section` table.
+-- Sourced directly from bubble_raw (not stg_bubble__class_section) for
+-- created_at/updated_at precision - see prod_academic_year_migration.sql for why.
+--
+-- section_display_name: no source column in bubble - per instruction, set equal to
+-- section_name (matches the target's own M6 backfill history: section_display_name
+-- was originally backfilled from section_name).
+--
+-- section_code: 10 rows use 'M'/'N', outside the target's documented A-L choices.
+-- No DB-level CHECK constraint exists on this column (just VARCHAR(1) + app-level
+-- choices), so passed through as-is per instruction rather than nulled out.
+--
+-- FK resolution:
+--   * school_class_id -> school_class._id -> school_class.school_class_id (stg_bubble__school_class)
+--     Nullable on the target, but 0 nulls/unresolved in bubble_raw as of this build.
+--   * school_id -> partner._id -> partner.partner_id (stg_bubble__partner)
+--     Loose/logical reference per the target schema (school_id is a plain BigIntegerField,
+--     not a DB-level FK) - 0 unmatched rows in bubble_raw as of this build.
+--
+-- created_by/updated_by: 8 rows have a null raw Created_By, and ~148 more carry a
+-- Created_By UUID with no matching row in bubble_raw."user". Falls back to the 'admin'
+-- user (user_id 477022) whenever unresolved, same rule as the other migration models.
+-- bubble tracks no separate "modified by" actor, so updated_by mirrors created_by.
+--
+-- Raw class_section_id is currently unique (1852 rows / 1852 distinct ids as of this
+-- build).
+
+with raw as (
+    select
+        "class_section_id"::bigint as class_section_id,
+        "school_class_id" as school_class_uuid,
+        "school_id" as school_uuid,
+        "section_code" as section_code,
+        "section_name" as section_name,
+        "is_active"::boolean as is_active,
+        "removed"::boolean as removed,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'class_section') }}
+),
+
+school_class_map as (
+    select "_id" as uuid, school_class_id
+    from {{ ref('stg_bubble__school_class') }}
+),
+partner_map as (
+    select partner_id as uuid, partner_id1 as school_id
+    from {{ ref('stg_bubble__partner') }}
+),
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+joined as (
+    select
+        raw.class_section_id,
+        school_class_map.school_class_id,
+        partner_map.school_id,
+        raw.section_code,
+        raw.section_name,
+        raw.section_name as section_display_name,
+        raw.is_active,
+        raw.removed,
+        raw.created_at,
+        raw.updated_at,
+        coalesce(user_map.user_id_number, 477022) as resolved_user_id
+    from raw
+    left join school_class_map on raw.school_class_uuid = school_class_map.uuid
+    left join partner_map on raw.school_uuid = partner_map.uuid
+    left join user_map on raw.created_by_uuid = user_map.uuid
+)
+
+select
+    class_section_id,
+    school_class_id,
+    school_id,
+    section_code,
+    section_name,
+    section_display_name,
+    is_active,
+    removed,
+    cast(null as timestamptz) as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from joined

--- a/models/gold/external_apps/prod_class_section_subject_migration.sql
+++ b/models/gold/external_apps/prod_class_section_subject_migration.sql
@@ -1,0 +1,77 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `class_section_subject` table.
+-- Sourced directly from bubble_raw (not stg_bubble__class_section_subject) for
+-- created_at/updated_at precision - see prod_academic_year_migration.sql for why.
+--
+-- Per the .md [FLAG] notes: neither FK has an explicit db_column set on the target
+-- Django model, so both get the doubled '_id_id' real column name. Output columns
+-- below use those exact doubled names (class_section_id_id, subject_id_id) per the
+-- "exact DB column names" convention agreed for this migration project.
+--
+-- FK resolution (both resolve cleanly, 0 unmatched rows in bubble_raw as of this build):
+--   * class_section_id_id -> class_section._id -> class_section.class_section_id (stg_bubble__class_section)
+--   * subject_id_id        -> subject._id        -> subject.subject_id            (stg_bubble__subject)
+--
+-- created_by/updated_by: 0 null/unresolved Created_By rows in bubble_raw as of this
+-- build, but the admin fallback (user_id 477022) is kept for parity with the other
+-- migration models in case future syncs introduce unresolved values. bubble tracks no
+-- separate "modified by" actor, so updated_by mirrors created_by.
+--
+-- Raw class_section_subject_id is currently unique (1087 rows / 1087 distinct ids as of
+-- this build).
+
+with raw as (
+    select
+        "class_section_subject_id"::bigint as class_section_subject_id,
+        "class_section_id" as class_section_uuid,
+        "subject_id" as subject_uuid,
+        "is_active"::boolean as is_active,
+        "removed"::boolean as removed,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'class_section_subject') }}
+),
+
+class_section_map as (
+    select "_id" as uuid, class_section_id
+    from {{ ref('stg_bubble__class_section') }}
+),
+subject_map as (
+    select "_id" as uuid, subject_id
+    from {{ ref('stg_bubble__subject') }}
+),
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+joined as (
+    select
+        raw.class_section_subject_id,
+        class_section_map.class_section_id,
+        subject_map.subject_id,
+        raw.is_active,
+        raw.removed,
+        raw.created_at,
+        raw.updated_at,
+        coalesce(user_map.user_id_number, 477022) as resolved_user_id
+    from raw
+    left join class_section_map on raw.class_section_uuid = class_section_map.uuid
+    left join subject_map on raw.subject_uuid = subject_map.uuid
+    left join user_map on raw.created_by_uuid = user_map.uuid
+)
+
+select
+    class_section_subject_id,
+    class_section_id as class_section_id,
+    subject_id as subject_id,
+    is_active,
+    removed,
+    cast(null as timestamptz) as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from joined

--- a/models/gold/external_apps/prod_program_migration.sql
+++ b/models/gold/external_apps/prod_program_migration.sql
@@ -1,0 +1,67 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `program` table (layer-0 reference
+-- catalog, e.g. 'Education Support'). Sourced directly from bubble_raw (not
+-- stg_bubble__program) for created_at/updated_at precision - see
+-- prod_academic_year_migration.sql for why.
+--
+-- is_active/removed: bubble_raw.program has neither column at all (confirmed against
+-- the live raw table). Hardcoded to true/false here, matching the target schema's own
+-- column defaults. Matches the .md's own note that this catalog is "effectively never
+-- deactivated in practice" anyway.
+--
+-- created_by/updated_by: the single current row's Created_By is the same synthetic
+-- 'admin_user_session-commencement_test' workflow identifier seen on class/academic_year,
+-- not a real user._id. Falls back to the 'admin' user (user_id 477022), same rule as the
+-- other migration models. bubble tracks no separate "modified by" actor, so updated_by
+-- mirrors created_by.
+--
+-- Raw program_id is currently unique (1 row / 1 distinct id as of this build) - kept the
+-- dedupe anyway for consistency/safety with the other migration models.
+
+with raw as (
+    select
+        "program_id"::bigint as program_id,
+        "program_name" as program_name,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'program') }}
+),
+
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+joined as (
+    select
+        raw.program_id,
+        raw.program_name,
+        raw.created_at,
+        raw.updated_at,
+        coalesce(user_map.user_id_number, 477022) as resolved_user_id
+    from raw
+    left join user_map on raw.created_by_uuid = user_map.uuid
+),
+
+deduplicated as (
+    {{ dbt_utils.deduplicate(
+        relation='joined',
+        partition_by='program_id',
+        order_by='updated_at desc',
+       )
+    }}
+)
+
+select
+    program_id,
+    program_name,
+    true as is_active,
+    false as removed,
+    cast(null as timestamptz) as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from deduplicated

--- a/models/gold/external_apps/prod_school_academic_year_migration.sql
+++ b/models/gold/external_apps/prod_school_academic_year_migration.sql
@@ -1,0 +1,96 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `school_academic_year` table.
+-- Sourced directly from bubble_raw (not stg_bubble__school_academic_year, and not
+-- int_bubble__school_academic_year) because:
+--   1. created_at/updated_at need full timestamp precision - see
+--      prod_academic_year_migration.sql for why bronze's ::date cast is unusable here.
+--   2. int_bubble__school_academic_year carries created_by as an unresolved raw UUID,
+--      not the resolved integer user_id the target needs - resolving independently here.
+--
+-- FK resolution:
+--   * school_id -> partner._id -> partner.partner_id (stg_bubble__partner)
+--     Raw integer per the target schema (not a DB-level FK, service-layer validated
+--     against partner.partner_id per the .md notes) - 0 unmatched rows in bubble_raw.
+--   * academic_year_id -> academic_year._id -> academic_year.academic_year_id
+--     (stg_bubble__academic_year) - 0 unmatched rows.
+--
+-- Checked the uniq_school_academic_year constraint (school_id, academic_year_id) where
+-- removed=false against current data: no violations found.
+--
+-- created_by/updated_by: 0 null raw Created_By, but 16 rows carry a Created_By UUID
+-- with no matching row in bubble_raw."user". Falls back to the 'admin' user (user_id
+-- 477022) whenever unresolved, same rule as the other migration models. bubble tracks
+-- no separate "modified by" actor, so updated_by mirrors created_by.
+--
+-- Raw school_academic_year_id is currently unique (176 rows / 176 distinct ids as of
+-- this build) - kept the dedupe anyway for consistency/safety with the other migration
+-- models.
+--
+-- Per the .md M7 notes: this model must be loaded into the target *after*
+-- prod_academic_year_migration.sql specifically - it's a hard FK dependency for
+-- school_class, school_session_details, and slot.
+
+with raw as (
+    select
+        "school_academic_year_id"::bigint as school_academic_year_id,
+        "school_id" as school_uuid,
+        "academic_year_id" as academic_year_uuid,
+        "is_active"::boolean as is_active,
+        "removed"::boolean as removed,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'school_academic_year') }}
+),
+
+partner_map as (
+    select partner_id as uuid, partner_id1 as school_id
+    from {{ ref('stg_bubble__partner') }}
+),
+academic_year_map as (
+    select "_id" as uuid, academic_year_id
+    from {{ ref('stg_bubble__academic_year') }}
+),
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+joined as (
+    select
+        raw.school_academic_year_id,
+        partner_map.school_id,
+        academic_year_map.academic_year_id,
+        raw.is_active,
+        raw.removed,
+        raw.created_at,
+        raw.updated_at,
+        coalesce(user_map.user_id_number, 477022) as resolved_user_id
+    from raw
+    left join partner_map on raw.school_uuid = partner_map.uuid
+    left join academic_year_map on raw.academic_year_uuid = academic_year_map.uuid
+    left join user_map on raw.created_by_uuid = user_map.uuid
+),
+
+deduplicated as (
+    {{ dbt_utils.deduplicate(
+        relation='joined',
+        partition_by='school_academic_year_id',
+        order_by='updated_at desc',
+       )
+    }}
+)
+
+select
+    school_academic_year_id,
+    school_id,
+    academic_year_id,
+    is_active,
+    removed,
+    cast(null as timestamptz) as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from deduplicated

--- a/models/gold/external_apps/prod_school_class_migration.sql
+++ b/models/gold/external_apps/prod_school_class_migration.sql
@@ -1,0 +1,105 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `school_class` table.
+-- Sourced directly from bubble_raw (not stg_bubble__school_class, and not
+-- int_bubble__school_class) because:
+--   1. created_at/updated_at need full timestamp precision - see
+--      prod_academic_year_migration.sql for why bronze's ::date cast is unusable here.
+--   2. int_bubble__school_class doesn't carry is_active or created_by through its
+--      select list, both of which the target schema needs - resolving independently
+--      here rather than modifying that shared silver model for one consumer.
+--
+-- FK resolution:
+--   * school_id -> partner._id -> partner.partner_id (stg_bubble__partner)
+--     Loose/logical reference per the target schema (school_id is a plain BigIntegerField,
+--     not a DB-level FK) - 0 unmatched rows in bubble_raw as of this build.
+--   * school_academic_year_id -> school_academic_year._id -> school_academic_year.school_academic_year_id
+--     (stg_bubble__school_academic_year) - 0 unmatched rows.
+--   * class_id -> class._id -> class.class_id (stg_bubble__class)
+--
+-- 8 rows have a NULL class_id in bubble_raw (6 of 8 are removed=true/is_active=false;
+-- 2 look "live"). class_id is NOT NULL on the target, so these rows can't load there -
+-- excluded here per instruction, same policy as the null class_section_id/program_id
+-- cases in the sibling migration models.
+--
+-- created_by/updated_by: 0 null raw Created_By, but ~24 rows carry a Created_By UUID
+-- with no matching row in bubble_raw."user". Falls back to the 'admin' user (user_id
+-- 477022) whenever unresolved, same rule as the other migration models. bubble tracks
+-- no separate "modified by" actor, so updated_by mirrors created_by.
+--
+-- Raw school_class_id is currently unique (397 rows / 397 distinct ids as of this
+-- build) - kept the dedupe anyway for consistency/safety with the other migration
+-- models.
+
+with raw as (
+    select
+        "school_class_id"::bigint as school_class_id,
+        "school_id" as school_uuid,
+        "school_academic_year_id" as school_academic_year_uuid,
+        "class_id" as class_uuid,
+        "is_active"::boolean as is_active,
+        "removed"::boolean as removed,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'school_class') }}
+),
+
+partner_map as (
+    select partner_id as uuid, partner_id1 as school_id
+    from {{ ref('stg_bubble__partner') }}
+),
+school_academic_year_map as (
+    select "_id" as uuid, school_academic_year_id
+    from {{ ref('stg_bubble__school_academic_year') }}
+),
+class_map as (
+    select "_id" as uuid, class_id
+    from {{ ref('stg_bubble__class') }}
+),
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+joined as (
+    select
+        raw.school_class_id,
+        partner_map.school_id,
+        school_academic_year_map.school_academic_year_id,
+        class_map.class_id,
+        raw.is_active,
+        raw.removed,
+        raw.created_at,
+        raw.updated_at,
+        coalesce(user_map.user_id_number, 477022) as resolved_user_id
+    from raw
+    left join partner_map on raw.school_uuid = partner_map.uuid
+    left join school_academic_year_map on raw.school_academic_year_uuid = school_academic_year_map.uuid
+    left join class_map on raw.class_uuid = class_map.uuid
+    left join user_map on raw.created_by_uuid = user_map.uuid
+    where class_map.class_id is not null
+),
+
+deduplicated as (
+    {{ dbt_utils.deduplicate(
+        relation='joined',
+        partition_by='school_class_id',
+        order_by='updated_at desc',
+       )
+    }}
+)
+
+select
+    school_class_id,
+    school_id,
+    school_academic_year_id,
+    class_id,
+    is_active,
+    removed,
+    cast(null as timestamptz) as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from deduplicated

--- a/models/gold/external_apps/prod_school_holiday_migration.sql
+++ b/models/gold/external_apps/prod_school_holiday_migration.sql
@@ -1,0 +1,103 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `school_holiday` table.
+-- Sourced directly from bubble_raw (not stg_bubble__school_holiday) for
+-- created_at/updated_at precision - see prod_academic_year_migration.sql for why - and
+-- because start_date/end_date need the same IST timezone fix as dob/date_of_enrollment
+-- in prod_child_migration.sql (every value carries the '18:30:00' UTC-midnight-IST
+-- signature; a direct ::date cast would be one day early).
+--
+-- holiday_reason: bubble_raw only has 2 rows today, with free-text-ish values
+-- ('MAD event (eg: YEC, etc)', 'Cancelled from school's end' - the raw apostrophe is a
+-- mangled encoding artifact) against the target's fixed choices (mad_event / holidays /
+-- cancelled_from_school_end). Mapped by prefix match per instruction; anything that
+-- doesn't match either prefix falls back to 'holidays' (the one choice with no current
+-- source value) so the column always gets a valid, non-null choice.
+--
+-- remarks: no source column in bubble_raw.school_holiday at all (confirmed against the
+-- live raw table) - left null (nullable on the target).
+--
+-- FK resolution: school_id -> partner._id -> partner.partner_id (stg_bubble__partner).
+-- Loose/logical reference per the target schema (school_id is a plain BigIntegerField,
+-- not a DB-level FK) - 0 unmatched rows in bubble_raw as of this build.
+--
+-- created_by/updated_by: 0 null/unresolved Created_By rows in bubble_raw as of this
+-- build, but the admin fallback (user_id 477022) is kept for parity with the other
+-- migration models. bubble tracks no separate "modified by" actor, so updated_by
+-- mirrors created_by.
+--
+-- Raw school_holiday_id is NOT unique in bubble_raw (2 rows / 1 distinct id as of this
+-- build) - deduplicated to one row per id, keeping the latest by Modified_Date.
+
+with raw as (
+    select
+        "school_holiday_id"::bigint as school_holiday_id,
+        "school_id" as school_uuid,
+        case
+            when "holiday_reason" ilike 'MAD event%' then 'mad_event'
+            when "holiday_reason" ilike 'Cancelled from school%' then 'cancelled_from_school_end'
+            else 'holidays'
+        end as holiday_reason,
+        (("start_date"::timestamptz) at time zone 'Asia/Kolkata')::date as start_date,
+        (("end_date"::timestamptz) at time zone 'Asia/Kolkata')::date as end_date,
+        "holiday_description" as holiday_description,
+        "is_active"::boolean as is_active,
+        "removed"::boolean as removed,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'school_holiday') }}
+),
+
+partner_map as (
+    select partner_id as uuid, partner_id1 as school_id
+    from {{ ref('stg_bubble__partner') }}
+),
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+joined as (
+    select
+        raw.school_holiday_id,
+        partner_map.school_id,
+        raw.holiday_reason,
+        raw.start_date,
+        raw.end_date,
+        raw.holiday_description,
+        raw.is_active,
+        raw.removed,
+        raw.created_at,
+        raw.updated_at,
+        coalesce(user_map.user_id_number, 477022) as resolved_user_id
+    from raw
+    left join partner_map on raw.school_uuid = partner_map.uuid
+    left join user_map on raw.created_by_uuid = user_map.uuid
+),
+
+deduplicated as (
+    {{ dbt_utils.deduplicate(
+        relation='joined',
+        partition_by='school_holiday_id',
+        order_by='updated_at desc',
+       )
+    }}
+)
+
+select
+    school_holiday_id,
+    school_id,
+    holiday_reason,
+    start_date,
+    end_date,
+    holiday_description,
+    cast(null as text) as remarks,
+    is_active,
+    removed,
+    cast(null as timestamptz) as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from deduplicated

--- a/models/gold/external_apps/prod_school_session_details_migration.sql
+++ b/models/gold/external_apps/prod_school_session_details_migration.sql
@@ -1,0 +1,99 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `school_session_details` table.
+-- Sourced directly from bubble_raw (not stg_bubble__school_session_detail) for
+-- created_at/updated_at precision - see prod_academic_year_migration.sql for why - and
+-- because start_date/end_date get the same IST timezone fix as dob/date_of_enrollment
+-- in prod_child_migration.sql. Here the raw time component is mixed (2/3 end_date rows
+-- at 00:00:00 UTC, the rest at the usual '18:30:00' UTC-midnight-IST signature); the
+-- Asia/Kolkata conversion is a no-op for the 00:00:00 UTC rows (same calendar day either
+-- way) and corrects the 18:30:00 ones, so applying it uniformly is safe.
+--
+-- Per the .md notes: the source field is named school_academic_year (no _id suffix), so
+-- Django assigns the plain db_column school_academic_year_id - no doubled-suffix gotcha
+-- here, unlike several sibling tables.
+--
+-- FK resolution (both resolve cleanly, 0 unmatched rows in bubble_raw as of this build):
+--   * school_id -> partner._id -> partner.partner_id (stg_bubble__partner). Loose/logical
+--     reference per the target schema (school_id is a plain BigIntegerField, not a
+--     DB-level FK).
+--   * school_academic_year_id -> school_academic_year._id -> school_academic_year.school_academic_year_id
+--     (stg_bubble__school_academic_year)
+--
+-- created_by/updated_by: 0 null/unresolved Created_By rows in bubble_raw as of this
+-- build, but the admin fallback (user_id 477022) is kept for parity with the other
+-- migration models. bubble tracks no separate "modified by" actor, so updated_by
+-- mirrors created_by.
+--
+-- Raw session_id is currently unique (3 rows / 3 distinct ids as of this build) - kept
+-- the dedupe anyway for consistency/safety with the other migration models.
+
+with raw as (
+    select
+        "session_id"::bigint as session_id,
+        "school_id" as school_uuid,
+        "school_academic_year" as school_academic_year_uuid,
+        (("start_date"::timestamptz) at time zone 'Asia/Kolkata')::date as start_date,
+        (("end_date"::timestamptz) at time zone 'Asia/Kolkata')::date as end_date,
+        "is_active"::boolean as is_active,
+        "removed"::boolean as removed,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'school_session_detail') }}
+),
+
+partner_map as (
+    select partner_id as uuid, partner_id1 as school_id
+    from {{ ref('stg_bubble__partner') }}
+),
+school_academic_year_map as (
+    select "_id" as uuid, school_academic_year_id
+    from {{ ref('stg_bubble__school_academic_year') }}
+),
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+joined as (
+    select
+        raw.session_id,
+        partner_map.school_id,
+        school_academic_year_map.school_academic_year_id,
+        raw.start_date,
+        raw.end_date,
+        raw.is_active,
+        raw.removed,
+        raw.created_at,
+        raw.updated_at,
+        coalesce(user_map.user_id_number, 477022) as resolved_user_id
+    from raw
+    left join partner_map on raw.school_uuid = partner_map.uuid
+    left join school_academic_year_map on raw.school_academic_year_uuid = school_academic_year_map.uuid
+    left join user_map on raw.created_by_uuid = user_map.uuid
+),
+
+deduplicated as (
+    {{ dbt_utils.deduplicate(
+        relation='joined',
+        partition_by='session_id',
+        order_by='updated_at desc',
+       )
+    }}
+)
+
+select
+    session_id,
+    school_id,
+    school_academic_year_id,
+    start_date,
+    end_date,
+    is_active,
+    removed,
+    cast(null as timestamptz) as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from deduplicated

--- a/models/gold/external_apps/prod_school_volunteer_migration.sql
+++ b/models/gold/external_apps/prod_school_volunteer_migration.sql
@@ -1,0 +1,106 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `school_volunteer` table.
+-- Sourced directly from bubble_raw (not stg_bubble__school_volunteer, and not
+-- int_bubble__school_volunteer) because:
+--   1. created_at/updated_at need full timestamp precision - see
+--      prod_academic_year_migration.sql for why bronze's ::date cast is unusable here.
+--   2. int_bubble__school_volunteer doesn't carry is_active or created_by through its
+--      select list, both of which the target schema needs.
+--
+-- Per the .md [FLAG] notes: neither volunteer_id nor school_academic_year_id has an
+-- explicit db_column set on the target Django model, so both get the doubled '_id_id'
+-- real column name (volunteer_id_id, school_academic_year_id_id).
+--
+-- school_id: 3894 of 5500 rows (71%) have a NULL school_id in bubble_raw - including
+-- 3868 rows that are is_active=true/removed=false (93% of all "active" rows), almost
+-- all bulk-created on a single day (2026-06-16), suggesting a batch operation in bubble
+-- that didn't set school_id. Investigated a proposed recovery path
+-- (school_volunteer.volunteer_id -> user._id -> user.worknode_id ->
+-- prod_chapter_mapping.worknode_id -> chapter_mapping.chapter_id -> bubble
+-- chapter.chapter_id -> chapter_school.school_id -> partner.partner_id): it only
+-- recovered 2 of 3894 rows, because chapter_mapping's chapter numbering (CRM/Google
+-- Sheet roster, all of MAD's chapters) doesn't correspond to bubble_raw.chapter's own
+-- numbering (session-ops-only, much smaller). Not viable - excluded here per
+-- instruction, same policy as the null-required-FK cases in the sibling migration
+-- models.
+--
+-- school_academic_year_id_id: no source column at all in bubble_raw.school_volunteer
+-- (confirmed against the live raw table) - left null (nullable on the target, and the
+-- .md notes this FK was made nullable in migration 0023 for this reason).
+--
+-- volunteer_id_id: 3 rows have a NULL raw volunteer_id. volunteer_id_id is NOT NULL on
+-- the target, so these are excluded too (on top of the school_id exclusions above).
+--
+-- created_by/updated_by: 8 rows have a null raw Created_By, and ~51 more carry a
+-- Created_By UUID with no matching row in bubble_raw."user". Falls back to the 'admin'
+-- user (user_id 477022) whenever unresolved, same rule as the other migration models,
+-- even though created_by is nullable on this target (unlike most other tables) - kept
+-- for consistency across all migration models. bubble tracks no separate "modified by"
+-- actor, so updated_by mirrors created_by.
+--
+-- Raw school_volunteer_id is not unique in bubble_raw (5500 rows / 5496 distinct ids as
+-- of this build) - deduplicated to one row per id, keeping the latest by Modified_Date.
+
+with raw as (
+    select
+        "school_volunteer_id"::bigint as school_volunteer_id,
+        "school_id" as school_uuid,
+        "volunteer_id" as volunteer_uuid,
+        "is_active"::boolean as is_active,
+        "removed"::boolean as removed,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'school_volunteer') }}
+),
+
+partner_map as (
+    select partner_id as uuid, partner_id1 as school_id
+    from {{ ref('stg_bubble__partner') }}
+),
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+joined as (
+    select
+        raw.school_volunteer_id,
+        partner_map.school_id,
+        volunteer_map.user_id_number as volunteer_id,
+        raw.is_active,
+        raw.removed,
+        raw.created_at,
+        raw.updated_at,
+        coalesce(created_by_map.user_id_number, 477022) as resolved_user_id
+    from raw
+    left join partner_map on raw.school_uuid = partner_map.uuid
+    left join user_map as volunteer_map on raw.volunteer_uuid = volunteer_map.uuid
+    left join user_map as created_by_map on raw.created_by_uuid = created_by_map.uuid
+    where partner_map.school_id is not null
+      and volunteer_map.user_id_number is not null
+),
+
+deduplicated as (
+    {{ dbt_utils.deduplicate(
+        relation='joined',
+        partition_by='school_volunteer_id',
+        order_by='updated_at desc',
+       )
+    }}
+)
+
+select
+    school_volunteer_id,
+    school_id,
+    volunteer_id as volunteer_id,
+    cast(null as bigint) as school_academic_year_id,
+    is_active,
+    removed,
+    cast(null as timestamptz) as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from deduplicated

--- a/models/gold/external_apps/prod_slot_class_section_migration.sql
+++ b/models/gold/external_apps/prod_slot_class_section_migration.sql
@@ -1,0 +1,109 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `slot_class_section` table.
+-- Sourced directly from bubble_raw (not stg_bubble__slot_class_section) for
+-- created_at/updated_at precision - see prod_academic_year_migration.sql for why.
+--
+-- Per the .md [FLAG] notes: all three FKs lack an explicit db_column on the target
+-- Django model, so all three get the doubled '_id_id' real column name
+-- (slot_id_id, class_section_id_id, class_section_subject_id_id). Per the .md's own
+-- notes this is a deliberate Bubble-schema-driven denormalization (class_section_id and
+-- class_section_subject_id both stored even though the latter implies the former) -
+-- carried through as-is, not deduplicated away.
+--
+-- FK resolution (all three resolve cleanly, 0 unmatched rows in bubble_raw as of this build):
+--   * slot_id_id                  -> slot._id                  -> slot.slot_id (stg_bubble__slot)
+--   * class_section_id_id         -> class_section._id         -> class_section.class_section_id (stg_bubble__class_section)
+--   * class_section_subject_id_id -> class_section_subject._id -> class_section_subject.class_section_subject_id
+--     (stg_bubble__class_section_subject)
+--
+-- created_by/updated_by: 0 null/unresolved Created_By rows in bubble_raw as of this
+-- build, but the admin fallback (user_id 477022) is kept for parity with the other
+-- migration models. bubble tracks no separate "modified by" actor, so updated_by
+-- mirrors created_by.
+--
+-- deleted_at: bubble has no dedicated deleted_at column, so it's derived rather than
+-- hardcoded null, per the 'scs' branch of the end-date logic in the old
+-- volunteer_allocation_history_e2_sessions.sql model (mad_dbt__old_models/
+-- intermediate_aggregation/session_ops/) - `WHEN scs.removed = TRUE THEN
+-- scs.modified_date`. When removed=true, deleted_at = updated_at (our resolved
+-- full-precision Modified_Date); otherwise null. Unlike that old model's fuller 'scsv'
+-- branch (used for slot_class_section_volunteer), no LEAD/LEAST capping against a next
+-- reassignment applies here - that logic is specific to volunteer reassignment history,
+-- not this table.
+--
+-- Raw slot_class_section_id is not unique in bubble_raw (1087 rows / 1085 distinct ids
+-- as of this build) - deduplicated to one row per id, keeping the latest by
+-- Modified_Date.
+
+with raw as (
+    select
+        "slot_class_section_id"::bigint as slot_class_section_id,
+        "slot_id" as slot_uuid,
+        "class_section_id" as class_section_uuid,
+        "class_section_subject_id" as class_section_subject_uuid,
+        "is_active"::boolean as is_active,
+        "removed"::boolean as removed,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'slot_class_section') }}
+),
+
+slot_map as (
+    select "_id" as uuid, slot_id
+    from {{ ref('stg_bubble__slot') }}
+),
+class_section_map as (
+    select "_id" as uuid, class_section_id
+    from {{ ref('stg_bubble__class_section') }}
+),
+class_section_subject_map as (
+    select "_id" as uuid, class_section_subject_id
+    from {{ ref('stg_bubble__class_section_subject') }}
+),
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+joined as (
+    select
+        raw.slot_class_section_id,
+        slot_map.slot_id,
+        class_section_map.class_section_id,
+        class_section_subject_map.class_section_subject_id,
+        raw.is_active,
+        raw.removed,
+        raw.created_at,
+        raw.updated_at,
+        coalesce(user_map.user_id_number, 477022) as resolved_user_id
+    from raw
+    left join slot_map on raw.slot_uuid = slot_map.uuid
+    left join class_section_map on raw.class_section_uuid = class_section_map.uuid
+    left join class_section_subject_map on raw.class_section_subject_uuid = class_section_subject_map.uuid
+    left join user_map on raw.created_by_uuid = user_map.uuid
+),
+
+deduplicated as (
+    {{ dbt_utils.deduplicate(
+        relation='joined',
+        partition_by='slot_class_section_id',
+        order_by='updated_at desc',
+       )
+    }}
+)
+
+select
+    slot_class_section_id,
+    slot_id as slot_id,
+    class_section_id as class_section_id,
+    class_section_subject_id as class_section_subject_id,
+    is_active,
+    removed,
+    case when removed then updated_at else cast(null as timestamptz) end as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from deduplicated

--- a/models/gold/external_apps/prod_slot_class_section_volunteer_migration.sql
+++ b/models/gold/external_apps/prod_slot_class_section_volunteer_migration.sql
@@ -1,0 +1,130 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `slot_class_section_volunteer` table.
+-- Sourced directly from bubble_raw (not stg_bubble__slot_class_section_volunteer, and
+-- not int_bubble__slot_class_section_volunteer) for created_at/updated_at precision -
+-- see prod_academic_year_migration.sql for why - and to compute a real deleted_at (see
+-- below).
+--
+-- Per the .md [FLAG] notes: both FKs lack an explicit db_column on the target Django
+-- model, so both get the doubled '_id_id' real column name (slot_class_section_id_id,
+-- volunteer_id_id). Both resolve cleanly, 0 unmatched rows in bubble_raw as of this
+-- build:
+--   * slot_class_section_id_id -> slot_class_section._id -> slot_class_section.slot_class_section_id
+--     (bubble_raw.slot_class_section directly, not stg - see parent_scs below)
+--   * volunteer_id_id           -> user._id                -> users.user_id (stg_bubble__user)
+--
+-- deleted_at: ported from the 'scsv' branch of volunteer_allocation_history_e2_sessions.sql
+-- (mad_dbt__old_models/intermediate_aggregation/session_ops/). bubble has no dedicated
+-- deleted_at column, and this row's own modified_date is not a trustworthy end-of-
+-- assignment timestamp: schema changes (e.g. adding an is_active column and backfilling
+-- it) and bulk archive jobs bump modified_date on already-removed rows with no real
+-- state change. Confirmed on real data: slot_class_section_volunteer_id 415 (removed,
+-- created_date 2025-09-12, modified_date 2026-03-16) and 1262 (same slot_class_section
+-- + volunteer, created_date 2026-01-29) - the service-layer rule "one active assignment
+-- per (slot_class_section, volunteer)" means 415 must have actually ended by
+-- 2026-01-29 when 1262 started, well before its modified_date of 2026-03-16.
+--   * If the PARENT slot_class_section is removed, deleted_at = the parent's
+--     modified_date (the assignment ended when the teaching slot itself did).
+--   * Else if this row is removed or is_active=false, deleted_at = LEAST(next
+--     reassignment's created_at, this row's own modified_date) - the next
+--     reassignment (same slot_class_section + volunteer) is a tighter, more
+--     trustworthy upper bound than a modified_date that bulk operations can inflate.
+--     Falls back to modified_date alone when there's no next reassignment.
+--   * Else (still active): null.
+-- Both rows 415 and 1262 are migrated as separate output rows (this is reassignment
+-- history, not CDC duplication) - dedup stays keyed on this table's own PK
+-- (slot_class_section_volunteer_id), consistent with every other migration model, not
+-- the old model's business-key dedup (which collapses rows for analytical purposes).
+--
+-- is_active: kept as a pure passthrough of this row's own raw is_active, per
+-- instruction - NOT cascaded from the parent's removed status the way the old model's
+-- recomputed is_active is. deleted_at alone carries the parent-removal signal.
+--
+-- created_by/updated_by: 0 null/unresolved Created_By rows in bubble_raw as of this
+-- build, but the admin fallback (user_id 477022) is kept for parity with the other
+-- migration models. bubble tracks no separate "modified by" actor, so updated_by
+-- mirrors created_by.
+--
+-- Raw slot_class_section_volunteer_id is currently unique (1588 rows / 1588 distinct
+-- ids as of this build).
+
+with raw as (
+    select
+        "slot_class_section_volunteer_id"::bigint as slot_class_section_volunteer_id,
+        "slot_class_section_id" as slot_class_section_uuid,
+        "volunteer_id" as volunteer_uuid,
+        "is_active"::boolean as is_active,
+        "removed"::boolean as removed,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'slot_class_section_volunteer') }}
+),
+
+slot_class_section_map as (
+    select "_id" as uuid, "slot_class_section_id"::bigint as slot_class_section_id
+    from {{ source('bubble_raw', 'slot_class_section') }}
+),
+parent_scs as (
+    select
+        "_id" as uuid,
+        "removed"::boolean as removed,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'slot_class_section') }}
+),
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+joined as (
+    select
+        raw.slot_class_section_volunteer_id,
+        slot_class_section_map.slot_class_section_id,
+        user_map.user_id_number as volunteer_id,
+        raw.is_active,
+        raw.removed,
+        raw.created_at,
+        raw.updated_at,
+        parent_scs.removed as parent_removed,
+        parent_scs.updated_at as parent_updated_at,
+        coalesce(user_map2.user_id_number, 477022) as resolved_user_id
+    from raw
+    left join slot_class_section_map on raw.slot_class_section_uuid = slot_class_section_map.uuid
+    left join parent_scs on raw.slot_class_section_uuid = parent_scs.uuid
+    left join user_map on raw.volunteer_uuid = user_map.uuid
+    left join user_map as user_map2 on raw.created_by_uuid = user_map2.uuid
+),
+
+with_next as (
+    select
+        *,
+        lead(created_at) over (
+            partition by slot_class_section_id, volunteer_id
+            order by created_at
+        ) as next_assignment_start
+    from joined
+)
+
+select
+    slot_class_section_volunteer_id,
+    slot_class_section_id as slot_class_section_id,
+    volunteer_id as volunteer_id,
+    is_active,
+    removed,
+    case
+        when parent_removed then parent_updated_at
+        when removed or not is_active then
+            case
+                when next_assignment_start is not null
+                    then least(next_assignment_start, updated_at)
+                else updated_at
+            end
+        else cast(null as timestamptz)
+    end as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from with_next

--- a/models/gold/external_apps/prod_slot_migration.sql
+++ b/models/gold/external_apps/prod_slot_migration.sql
@@ -1,0 +1,123 @@
+{{ config(materialized='table') }}
+
+-- Migration feed for session-ops platform's `slot` table.
+-- Sourced directly from bubble_raw (not stg_bubble__slot, and not int_bubble__slot)
+-- because:
+--   1. created_at/updated_at need full timestamp precision - see
+--      prod_academic_year_migration.sql for why bronze's ::date cast is unusable here.
+--   2. start_time/end_time need the same IST timezone fix as dob/date_of_enrollment in
+--      prod_child_migration.sql: raw values are full UTC timestamps (arbitrary dates,
+--      only the time-of-day matters for the target's TIME columns), entered as IST
+--      wall-clock time. Converted to Asia/Kolkata before taking ::time here so the
+--      migrated time matches what was actually entered.
+--   3. int_bubble__slot doesn't carry created_by through, and stg_bubble__slot casts
+--      start_time/end_time to plain ::timestamp (dropping the timezone info needed for
+--      the fix above).
+--
+-- day_of_week: raw values are capitalized ('Tuesday') vs the target's lowercase choices
+-- (monday..sunday) - lowercased. 3 rows have a NULL raw day_of_week; rather than exclude
+-- them, derived the day name from start_time itself (same IST-converted timestamp,
+-- to_char(..., 'Day')) since the information already exists in the same row.
+--
+-- Per the .md [FLAG] notes: school_academic_year_id has no explicit db_column set on
+-- the target Django model, so it gets the doubled 'school_academic_year_id_id' real
+-- column name.
+--
+-- recurring: sourced from bubble_raw's "reccuring" column (note the raw typo).
+--
+-- FK resolution (both resolve cleanly, 0 unmatched rows in bubble_raw as of this build):
+--   * school_id -> partner._id -> partner.partner_id (stg_bubble__partner). Loose/logical
+--     reference per the target schema (school_id is a plain BigIntegerField, not a
+--     DB-level FK).
+--   * school_academic_year_id_id -> school_academic_year._id -> school_academic_year.school_academic_year_id
+--     (stg_bubble__school_academic_year)
+--
+-- created_by/updated_by: 1 row has a null raw Created_By, and ~4 more carry a Created_By
+-- UUID with no matching row in bubble_raw."user". Falls back to the 'admin' user
+-- (user_id 477022) whenever unresolved, same rule as the other migration models. bubble
+-- tracks no separate "modified by" actor, so updated_by mirrors created_by.
+--
+-- Raw slot_id is currently unique (178 rows / 178 distinct ids as of this build) - kept
+-- the dedupe anyway for consistency/safety with the other migration models.
+
+with raw as (
+    select
+        "slot_id"::bigint as slot_id,
+        "school_id" as school_uuid,
+        "school_academic_year_id" as school_academic_year_uuid,
+        "slot_name" as slot_name,
+        coalesce(
+            lower("day_of_week"),
+            lower(trim(to_char((("start_time"::timestamptz)) at time zone 'Asia/Kolkata', 'Day')))
+        ) as day_of_week,
+        (("start_time"::timestamptz) at time zone 'Asia/Kolkata')::time as start_time,
+        (("end_time"::timestamptz) at time zone 'Asia/Kolkata')::time as end_time,
+        "reccuring"::boolean as recurring,
+        "is_active"::boolean as is_active,
+        "removed"::boolean as removed,
+        "Created_By" as created_by_uuid,
+        "Created_Date"::timestamptz as created_at,
+        "Modified_Date"::timestamptz as updated_at
+    from {{ source('bubble_raw', 'slot') }}
+),
+
+partner_map as (
+    select partner_id as uuid, partner_id1 as school_id
+    from {{ ref('stg_bubble__partner') }}
+),
+school_academic_year_map as (
+    select "_id" as uuid, school_academic_year_id
+    from {{ ref('stg_bubble__school_academic_year') }}
+),
+user_map as (
+    select user_id as uuid, user_id_number
+    from {{ ref('stg_bubble__user') }}
+),
+
+joined as (
+    select
+        raw.slot_id,
+        partner_map.school_id,
+        school_academic_year_map.school_academic_year_id,
+        raw.slot_name,
+        raw.day_of_week,
+        raw.start_time,
+        raw.end_time,
+        raw.recurring,
+        raw.is_active,
+        raw.removed,
+        raw.created_at,
+        raw.updated_at,
+        coalesce(user_map.user_id_number, 477022) as resolved_user_id
+    from raw
+    left join partner_map on raw.school_uuid = partner_map.uuid
+    left join school_academic_year_map on raw.school_academic_year_uuid = school_academic_year_map.uuid
+    left join user_map on raw.created_by_uuid = user_map.uuid
+),
+
+deduplicated as (
+    {{ dbt_utils.deduplicate(
+        relation='joined',
+        partition_by='slot_id',
+        order_by='updated_at desc',
+       )
+    }}
+)
+
+select
+    slot_id,
+    school_id,
+    school_academic_year_id as school_academic_year_id,
+    slot_name,
+    day_of_week,
+    start_time,
+    end_time,
+    recurring,
+    is_active,
+    removed,
+    cast(null as timestamptz) as deleted_at,
+    created_at,
+    updated_at,
+    resolved_user_id as created_by_id,
+    resolved_user_id as updated_by_id
+from deduplicated


### PR DESCRIPTION
added 19 new models from bubble bronze to prod from migration bubble data in new session_ops v2